### PR TITLE
Setting timeout to be an integer

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -38,7 +38,7 @@ def pytest_addoption(parser):
         help="specify the browser")
     parser.addoption("--site", action="store", default="http://support.allizom.org",
         help="specify the AUT")
-    parser.addoption("--timeout", action="store", default=120000,
+    parser.addoption("--timeout", action="store", type="int", default=120000,
         help="specify the timeout")
 
 


### PR DESCRIPTION
See https://github.com/mozilla/Addon-Tests/pull/74/ for more detail;
basically "timeout" can get set as a string if it's not typed as an int
in conftest.py
