### PR TITLE
Begone from prod, for now!

### DIFF
--- a/test_no_query_adv_forum_search.py
+++ b/test_no_query_adv_forum_search.py
@@ -46,7 +46,6 @@ class TestNoQueryAdvForumSearch:
     @pytest.mark.smoketests
     @pytest.mark.bft
     @pytest.mark.fft
-    @pytest.mark.prod
     def test_no_query_adv_forum_search(self, mozwebqa):
         login_pg = LoginPage(mozwebqa)
         refine_search_pg = RefineSearchPage(mozwebqa)


### PR DESCRIPTION
Let's remove the @prod marker -- we'll either remove this test, or rewrite it to be useful across prod/stage, later.
