### PR TITLE
Ping pytest to 2.1.3 and pytest-xdist to 1.6

### DIFF
--- a/requirements/mozwebqa.txt
+++ b/requirements/mozwebqa.txt
@@ -1,7 +1,7 @@
 # This pulls in all the libraries needed to run Selenium tests
 # on Mozilla WebQA projects
 selenium
-pytest
-pytest-xdist
+pytest==2.1.3
+pytest-xdist==1.6
 pytest-mozwebqa
 unittestzero


### PR DESCRIPTION
...ssue Dave's pointed out with py.test 2.2.0 (see what he did in https://github.com/mozilla/input-tests/commit/88cab650745e8cddbeadecd59090eb21c67992ac), and the discussion on the mozwebqa mailing list, as well as the issue filed here: https://bitbucket.org/hpk42/pytest/issue/93
