### PR TITLE
See the latest logs for sumo.release; this should fix the single redirect case that's failing due to a URL change

### DIFF
--- a/tests/desktop/test_rewrites.py
+++ b/tests/desktop/test_rewrites.py
@@ -261,7 +261,7 @@ class TestRewrites(unittest.TestCase):
         
         """ redirect old mobile URLs to new SUMO URLs
         http://support.allizom.org/1/mobile/4.0/android/en-US/firefox-help ->
-        http://support.mozilla.org/en-US/mobile
+        http://support.allizom.org/en-US/mobile
         """
         platform  = "/mobile"
         mobile_os = ('/android','/iphone', '/nokia')


### PR DESCRIPTION
Traceback (most recent call last):
  File "tests/desktop/test_rewrites.py", line 279, in test_redirect_misc
    self.assert_(expectedStr in actual_url)

The URL has changed; I've updated the comment too.

Basically, we used to do:

http://support.allizom.org/1/mobile/4.0/android/en-US/firefox-help ->
http://www.mozilla.com/en-US/m/support/

But we now do:

[11:53:31.313] GET http://support.allizom.org/1/mobile/4.0/android/en-US/firefox-help [HTTP/1.1 302 FOUND 68ms]
[11:53:31.385] GET http://support.allizom.org/en-US/mobile?as=u [HTTP/1.1 200 OK 98ms]
