### PR TITLE
Editing tools wait

### DIFF
--- a/pages/desktop/knowledge_base_article.py
+++ b/pages/desktop/knowledge_base_article.py
@@ -27,7 +27,7 @@ class KnowledgeBase(Base):
         def show_editing_tools(self):
             if self.is_element_visible(*self._show_editing_tools_locator):
                 self.selenium.find_element(*self._show_editing_tools_locator).click()
-            self.wait_for_element_visible(*self._editing_tools_locator)
+                self.wait_for_element_visible(*self._editing_tools_locator)
             
         def click_article(self):
             self.show_editing_tools()


### PR DESCRIPTION
This ran ok locally but over my grid to the windows machine it behaved a bit differently and the step after this was not being completed correctly, so to be safe I added an explicit wait for all the items in the doc menu to be visible before the next step.
