### PR TITLE
Update plugin and marks

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,14 @@
 # This pulls in all the libraries needed to run Selenium tests
 # on Mozilla WebQA projects
+
 PyYAML==3.10
 UnittestZero
 certifi==0.0.8
+chardet==1.0.1
 execnet==1.0.9
 py==1.4.7
 pytest==2.2.3
-pytest-mozwebqa==0.8
+pytest-mozwebqa==0.9
 pytest-xdist==1.8
-requests==0.9.1
+requests==0.10.8
 selenium

--- a/tests/desktop/test_article_create_edit_delete.py
+++ b/tests/desktop/test_article_create_edit_delete.py
@@ -12,12 +12,10 @@ from pages.desktop.login_page import LoginPage
 import re
 import pytest
 import datetime
-xfail = pytest.mark.xfail
 
 
 class TestArticleCreateEditDelete:
 
-    @pytest.mark.fft
     def test_that_article_can_be_created(self, mozwebqa):
         """
            Creates a new knowledge base article.
@@ -52,8 +50,7 @@ class TestArticleCreateEditDelete:
         kb_edit_article.navigation.click_show_history()
         kb_article_history.delete_entire_article_document()
 
-    @xfail(reason='Bug 694614 - spurious failures')
-    @pytest.mark.fft
+    @pytest.mark.xfail(reason='Bug 694614 - spurious failures')
     def test_that_article_can_be_edited(self, mozwebqa):
         """
            Creates a new knowledge base article.
@@ -103,7 +100,6 @@ class TestArticleCreateEditDelete:
         kb_edit_article.navigation.click_show_history()
         kb_article_history.delete_entire_article_document()
 
-    @pytest.mark.fft
     def test_that_article_can_be_deleted(self, mozwebqa):
         """
            Creates a new knowledge base article.
@@ -135,7 +131,6 @@ class TestArticleCreateEditDelete:
         actual_page_title = kb_article_history.page_title
         Assert.contains("Page Not Found", actual_page_title)
 
-    @pytest.mark.fft
     def test_that_article_can_be_previewed_before_submitting(self, mozwebqa):
 
         kb_new_article = KnowledgeBaseNewArticle(mozwebqa)
@@ -153,7 +148,6 @@ class TestArticleCreateEditDelete:
 
         # Does not need to be deleted as it does not commit the article
 
-    @pytest.mark.fft
     def test_that_article_can_be_translated(self, mozwebqa):
         """
            Creates a new knowledge base article.

--- a/tests/desktop/test_loggedin_ask_a_new_question.py
+++ b/tests/desktop/test_loggedin_ask_a_new_question.py
@@ -6,14 +6,10 @@ from unittestzero import Assert
 from pages.desktop.questions_page import ViewQuestionPage
 from pages.desktop.questions_page import AskNewQuestionsPage
 import datetime
-import pytest
 
 
 class TestAAQ:
 
-    @pytest.mark.smoketests
-    @pytest.mark.bft
-    @pytest.mark.fft
     def test_that_posting_question_works(self, mozwebqa):
         """Posts a question to /questions"""
         ask_new_questions_pg = AskNewQuestionsPage(mozwebqa)

--- a/tests/desktop/test_new_user_registration.py
+++ b/tests/desktop/test_new_user_registration.py
@@ -4,12 +4,10 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 from unittestzero import Assert
 from pages.desktop.register_page import RegisterPage
-import pytest
 
 
 class TestNewUserRegistration:
 
-    @pytest.mark.fft
     def test_that_thank_you_page_is_displayed_after_successful_registration(self, mozwebqa):
         """
            Register a new user using random username.

--- a/tests/desktop/test_questions_problem_count.py
+++ b/tests/desktop/test_questions_problem_count.py
@@ -4,13 +4,10 @@
 from unittestzero import Assert
 from pages.desktop.questions_page import ViewQuestionPage
 from pages.desktop.questions_page import QuestionsPage
-import pytest
 
 
 class TestQuestionProbCount:
 
-    @pytest.mark.bft
-    @pytest.mark.fft
     def test_that_questions_problem_count_increments(self, mozwebqa):
         """Checks if the 'I have this problem too' counter increments"""
 

--- a/tests/desktop/test_questions_sort.py
+++ b/tests/desktop/test_questions_sort.py
@@ -9,8 +9,7 @@ import pytest
 
 class TestQuestionsSort:
 
-    @pytest.mark.fft
-    @pytest.mark.prod
+    @pytest.mark.nondestructive
     def test_that_questions_sorts_correctly_by_filter_equal_to_solved(self, mozwebqa):
         """
            Goes to the /questions page,
@@ -30,8 +29,7 @@ class TestQuestionsSort:
             actual_sorted_text = questions_pg.sorted_list_filter_text(counter + 1)
             Assert.equal(actual_sorted_text, expected_sorted_text)
 
-    @pytest.mark.fft
-    @pytest.mark.prod
+    @pytest.mark.nondestructive
     def test_that_questions_sorts_correctly_by_filter_equal_to_no_replies(self, mozwebqa):
         """
            Goes to the /questions page,

--- a/tests/desktop/test_rewrites.py
+++ b/tests/desktop/test_rewrites.py
@@ -10,7 +10,6 @@ import requests
 import urllib
 
 
-@pytest.mark.fft
 @pytest.mark.skip_selenium
 @pytest.mark.nondestructive
 class TestRedirects:

--- a/tests/desktop/test_search.py
+++ b/tests/desktop/test_search.py
@@ -9,10 +9,7 @@ import pytest
 
 class TestSearch:
 
-    @pytest.mark.smoketests
-    @pytest.mark.bft
-    @pytest.mark.fft
-    @pytest.mark.prod
+    @pytest.mark.nondestructive
     @pytest.mark.parametrize(('search_term'), [
         ('firefox'),
         ('bgkhdsaghb')])
@@ -26,9 +23,6 @@ class TestSearch:
         Assert.contains(expected_text, search_page_obj.ask_a_question_text)
         Assert.true(search_page_obj.is_ask_a_question_present, "Ask question link not present")
 
-    @pytest.mark.smoketests
-    @pytest.mark.bft
-    @pytest.mark.fft
     @pytest.mark.xfail(reason='Bug 710361 - Empty/default advanced searches fail/time out')
     def test_no_query_adv_forum_search(self, mozwebqa):
         refine_search_pg = RefineSearchPage(mozwebqa)

--- a/tests/desktop/test_view_helpfulness_chart.py
+++ b/tests/desktop/test_view_helpfulness_chart.py
@@ -7,11 +7,10 @@ from unittestzero import Assert
 from pages.desktop.support_home_page import SupportHomePage
 from pages.desktop.knowledge_base_article import KnowledgeBaseArticle
 from pages.desktop.knowledge_base_article import KnowledgeBaseShowHistory
-import pytest
+
 
 class TestViewHelpfulnessChart:
 
-    @pytest.mark.fft
     def test_view_helpfulness_chart(self, mozwebqa):
         """
            Creates a new knowledge base article.


### PR DESCRIPTION
After doing a little look over the marks I realised that every test that remains after our recent cleanup was marked with `fft` thus making it quite pointless.

To bring the tests inline with the new 0.9 plugin I converted the `prod` markers into `nondestructive` and removed `bft` and `smoke` marks which were unused.

There are no native events used in this suite so `native` is not present.

The sumo jobs will need to be updated.
