### PR TITLE
[redesign]Fix  for TestSearch.test_search_returns_either_term

### DIFF
--- a/pages/desktop/search_page.py
+++ b/pages/desktop/search_page.py
@@ -14,8 +14,10 @@ class SearchPage(Base):
 
     _page_title = 'Search | Mozilla Support'
     _page_url = '/en-US/search'
-    _search_box = (By.CSS_SELECTOR, 'input.search-query')
+    _search_query_locator = (By.CSS_SELECTOR, 'input.search-query')
+    _search_box_locator = (By.CSS_SELECTOR, 'input.searchbox')
     _search_button = (By.CSS_SELECTOR, 'input[type="submit"]')
+    _search_support_button_locator = (By.CSS_SELECTOR, 'form.search-form > button.btn')
     _refine_search_link = (By.CSS_SELECTOR, 'a[href *= "a=2"]')
     _next_page_link = (By.LINK_TEXT, 'Next')
     _prev_page_link = (By.LINK_TEXT, 'Previous')
@@ -26,11 +28,17 @@ class SearchPage(Base):
     _search_unavailable_msg = 'unavailable'
     _results_list_locator = (By.CSS_SELECTOR, 'div.search-results div[class*="result"]')
 
-    def do_search_on_search_box(self, search_query):
+    def do_search_on_search_query(self, search_query):
         if not (self._page_title in self.selenium.title):
             self.go_to_search_page()
-        self.selenium.find_element(*self._search_box).send_keys(search_query)
+        self.selenium.find_element(*self._search_query_locator).send_keys(search_query)
         self.selenium.find_element(*self._search_button).click()
+    
+    def do_search_on_search_box(self, search_term):
+        if not (self._page_title in self.selenium.title):
+            self.go_to_search_page()
+        self.selenium.find_element(*self._search_box_locator).send_keys(search_term)
+        self.selenium.find_element(*self._search_support_button_locator).click()
 
     def get_search_box_value(self):
         return self.selenium.find_element(*self._search_box).value

--- a/tests/desktop/test_search.py
+++ b/tests/desktop/test_search.py
@@ -15,7 +15,7 @@ class TestSearch:
         ('bgkhdsaghb')])
     def test_cant_find_what_youre_looking_for_test(self, mozwebqa, search_term):
         search_page_obj = PageProvider(mozwebqa).search_page()
-        search_page_obj.do_search_on_search_box(search_term)
+        search_page_obj.do_search_on_search_query(search_term)
 
         expected_text = "Can't find what you're looking for?"
         Assert.contains(expected_text, search_page_obj.ask_a_question_text)
@@ -49,7 +49,7 @@ class TestSearch:
         search_page_obj = PageProvider(mozwebqa).search_page()
 
         # search with good search term only.  save first search result.
-        search_page_obj.do_search_on_search_box(good_search_term)
+        search_page_obj.do_search_on_search_query(good_search_term)
         Assert.true(search_page_obj.is_result_present, "1st search has no results")
         result_search_1 = search_page_obj.get_result_text
 


### PR DESCRIPTION
The search box and search button now have different locators depending
on the page that's opened.
I added the appropriate locators to reflect the change.

There still are 2 tests failing in that file, but those are unrelated to this pull.
