### PR TITLE
Removed TestSearch.test_cant_find_what_youre_looking_for_test

### DIFF
--- a/pages/desktop/search_page.py
+++ b/pages/desktop/search_page.py
@@ -22,8 +22,6 @@ class SearchPage(Base):
     _next_page_link = (By.LINK_TEXT, 'Next')
     _prev_page_link = (By.LINK_TEXT, 'Previous')
     _result_div = (By.CSS_SELECTOR, 'div.result')
-    _ask_a_question_locator = (By.CSS_SELECTOR, 'p.aaq')
-    _support_question_link = (By.CSS_SELECTOR, 'p.aaq > a')
     _second_page_link = (By.LINK_TEXT, '2')
     _search_unavailable_msg = 'unavailable'
     _results_list_locator = (By.CSS_SELECTOR, 'div.search-results div[class*="result"]')
@@ -61,11 +59,3 @@ class SearchPage(Base):
 
     def click_next_page_link(self):
         self.selenium.find_element(*self._next_page_link).click()
-
-    @property
-    def ask_a_question_text(self):
-        return self.selenium.find_element(*self._ask_a_question_locator).text
-
-    @property
-    def is_ask_a_question_present(self):
-        return self.is_element_present(*self._support_question_link)

--- a/tests/desktop/test_search.py
+++ b/tests/desktop/test_search.py
@@ -9,18 +9,6 @@ from pages.desktop.page_provider import PageProvider
 
 class TestSearch:
 
-    @pytest.mark.nondestructive
-    @pytest.mark.parametrize(('search_term'), [
-        ('firefox'),
-        ('bgkhdsaghb')])
-    def test_cant_find_what_youre_looking_for_test(self, mozwebqa, search_term):
-        search_page_obj = PageProvider(mozwebqa).search_page()
-        search_page_obj.do_search_on_search_query(search_term)
-
-        expected_text = "Can't find what you're looking for?"
-        Assert.contains(expected_text, search_page_obj.ask_a_question_text)
-        Assert.true(search_page_obj.is_ask_a_question_present, "Ask question link not present")
-
     @pytest.mark.xfail(reason='Bug 710361 - Empty/default advanced searches fail/time out')
     @pytest.mark.native
     @pytest.mark.nondestructive


### PR DESCRIPTION
"Can't find what you're looking for? Ask a question on our
community support forum." was removed from the search pages
in support.allizom.org
I've talked to r1cky in #sumodev channel and he said we should
remove this test.
