### PR TITLE
Add methods to enable confirmation of logout to be sped up

### DIFF
--- a/pages/desktop/base.py
+++ b/pages/desktop/base.py
@@ -68,3 +68,6 @@ class Base(Page):
         @property
         def is_user_logged_in(self):
             return self.is_element_visible(*self._account_controller_locator)
+        
+        def get_logged_in_element(self):
+            return self.get_element(*self._account_controller_locator)

--- a/pages/page.py
+++ b/pages/page.py
@@ -14,6 +14,7 @@ from unittestzero import Assert
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.common.exceptions import NoSuchElementException
 from selenium.common.exceptions import ElementNotVisibleException
+from selenium.common.exceptions import StaleElementReferenceException
 
 http_regex = re.compile('https?://((\w+\.)+\w+\.\w+)')
 
@@ -64,6 +65,21 @@ class Page(object):
         finally:
             # set back to where you once belonged
             self.selenium.implicitly_wait(self.testsetup.default_implicit_wait)
+    
+    def get_element(self, *locator):
+        try:
+            return self.selenium.find_element(*locator)
+        except NoSuchElementException:
+            # this will return a snapshot, which takes time.
+            return None
+    
+    #https://github.com/Dude-X/Selenium2/blob/pythonExpected/py/selenium/webdriver/support/expected_conditions.py
+    def is_element_stale(self, element):
+        try:
+            element.is_enabled()
+            return False
+        except StaleElementReferenceException as expected:
+            return True
             
     def is_element_visible(self, *locator):
         try:

--- a/tests/desktop/test_login_logout.py
+++ b/tests/desktop/test_login_logout.py
@@ -34,9 +34,10 @@ class TestLoginLogout:
         Assert.true(page_under_test.header.is_user_logged_in, 'User not shown to be logged in')
 
         # sign out
+        signed_in_element = page_under_test.header.get_logged_in_element()
         home_page = page_under_test.sign_out()
         home_page.is_the_current_page
-        Assert.false(home_page.header.is_user_logged_in)
+        Assert.true(page_under_test.is_element_stale(signed_in_element), 'User not shown to be logged out')
 
     @pytest.mark.native
     def test_logout_from_new_kb_article_page(self, mozwebqa):
@@ -44,9 +45,10 @@ class TestLoginLogout:
         Assert.true(new_kb_page.header.is_user_logged_in, 'User not shown to be logged in')
 
         # sign out
+        signed_in_element = new_kb_page.header.get_logged_in_element()
         home_page = new_kb_page.sign_out()
         home_page.is_the_current_page
-        Assert.false(home_page.header.is_user_logged_in)
+        Assert.true(new_kb_page.is_element_stale(signed_in_element), 'User not shown to be logged out')
 
     @pytest.mark.native
     def test_logout_from_edit_kb_article_page(self, mozwebqa):
@@ -61,9 +63,10 @@ class TestLoginLogout:
         kb_edit_article = kb_article_history.navigation.click_edit_article()
 
         # sign out
+        signed_in_element = kb_edit_article.header.get_logged_in_element()
         home_page = kb_edit_article.sign_out()
         home_page.is_the_current_page
-        Assert.false(home_page.header.is_user_logged_in)
+        Assert.true(kb_edit_article.is_element_stale(signed_in_element), 'User not shown to be logged out')
 
     @pytest.mark.native
     def test_logout_from_translate_kb_article_page(self, mozwebqa):
@@ -79,6 +82,7 @@ class TestLoginLogout:
         kb_translate_pg.click_translate_language('Esperanto (eo)')
 
         # sign out
+        signed_in_element = kb_translate_pg.header.get_logged_in_element()
         home_page = kb_translate_pg.sign_out()
         home_page.is_the_current_page
-        Assert.false(home_page.header.is_user_logged_in)
+        Assert.true(kb_translate_pg.is_element_stale(signed_in_element), 'User not shown to be logged out')


### PR DESCRIPTION
Confirm a stale element rather than waiting for something not to be present. This saves 10s x8 on runs of test_login_logout
