### PR TITLE
New faster test for logout - confirms SignIn button

### DIFF
--- a/pages/desktop/base.py
+++ b/pages/desktop/base.py
@@ -68,3 +68,7 @@ class Base(Page):
         @property
         def is_user_logged_in(self):
             return self.is_element_visible(*self._account_controller_locator)
+
+        @property
+        def is_user_logged_out(self):
+            return self.is_element_visible(*self._login_locator)

--- a/tests/desktop/test_login_logout.py
+++ b/tests/desktop/test_login_logout.py
@@ -36,7 +36,7 @@ class TestLoginLogout:
         # sign out
         home_page = page_under_test.sign_out()
         home_page.is_the_current_page
-        Assert.false(home_page.header.is_user_logged_in)
+        Assert.true(home_page.header.is_user_logged_out)
 
     @pytest.mark.native
     def test_logout_from_new_kb_article_page(self, mozwebqa):
@@ -46,7 +46,7 @@ class TestLoginLogout:
         # sign out
         home_page = new_kb_page.sign_out()
         home_page.is_the_current_page
-        Assert.false(home_page.header.is_user_logged_in)
+        Assert.true(home_page.header.is_user_logged_out)
 
     @pytest.mark.native
     def test_logout_from_edit_kb_article_page(self, mozwebqa):
@@ -63,7 +63,7 @@ class TestLoginLogout:
         # sign out
         home_page = kb_edit_article.sign_out()
         home_page.is_the_current_page
-        Assert.false(home_page.header.is_user_logged_in)
+        Assert.true(home_page.header.is_user_logged_out)
 
     @pytest.mark.native
     def test_logout_from_translate_kb_article_page(self, mozwebqa):
@@ -81,4 +81,4 @@ class TestLoginLogout:
         # sign out
         home_page = kb_translate_pg.sign_out()
         home_page.is_the_current_page
-        Assert.false(home_page.header.is_user_logged_in)
+        Assert.true(home_page.header.is_user_logged_out)


### PR DESCRIPTION
Based on the comments in Pull Request #160 this is a new attempt at asserting IsLoggedOut that should be 10s quicker per call than Assert.False(is_logged_in) but much simpler than my previous attempt.
