### PR TITLE
sites affected field has been removed from the 'ask a question' UI

### DIFF
--- a/pages/desktop/questions_page.py
+++ b/pages/desktop/questions_page.py
@@ -98,7 +98,6 @@ class AskNewQuestionsPage(Base):
     _ask_this_button_locator = (By.CSS_SELECTOR, '#ask-search-form .btn.btn-important')
     _none_of_these_button_locator = (By.CSS_SELECTOR, 'form .btn.btn-submit')
     _q_content_box_locator = (By.ID, 'id_content')
-    _q_site_box_locator = (By.ID, 'id_sites_affected')
     _q_trouble_box_locator = (By.ID, 'id_troubleshooting')
     _q_post_button_locator = (By.CSS_SELECTOR, 'li.submit button.btn')
     _sort_solved_link_locator = (By.CSS_SELECTOR, 'a[href*=filter=solved]')
@@ -122,7 +121,6 @@ class AskNewQuestionsPage(Base):
 
     def fill_up_questions_form(self, question_to_ask, q_text='details', q_site='www.example.com', q_trouble='no addons'):
         self.selenium.find_element(*self._q_content_box_locator).send_keys(q_text)
-        self.selenium.find_element(*self._q_site_box_locator).send_keys(q_site)
         self.selenium.find_element(*self._q_trouble_box_locator).send_keys(q_trouble)
         self.selenium.find_element(*self._q_post_button_locator).click()
         view_question_pg = ViewQuestionPage(self.testsetup)


### PR DESCRIPTION
this PR is in response to https://bugzilla.mozilla.org/show_bug.cgi?id=810928, https://github.com/mozilla/kitsune/pull/956/files#L1L16

i am _not_ sure it is the correct solution. the commit shows every category that had 'extra_fields' now does not have them. this might be a bug that needs to be filed, or it might have been information that wasn't being used for anything anyway.
