### PR TITLE
Xfailed TestKnowledgeBaseArticle.test_view_helpfulness_chart

### DIFF
--- a/tests/desktop/test_kb_article.py
+++ b/tests/desktop/test_kb_article.py
@@ -156,6 +156,7 @@ class TestKnowledgeBaseArticle:
         # deleting
         kb_article_history.delete_entire_article_document()
 
+    @pytest.mark.xfail(reason='Bug 814002 - "Error loading chart" shown when "Show Helpfulness Votes Chart" is clicked')
     @pytest.mark.nondestructive
     def test_view_helpfulness_chart(self, mozwebqa):
         """


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=814002
"Error loading chart" shown when "Show Helpfulness Votes Chart" is clicked
