### PR TITLE
Fix for TestQuestions.test_that_posting_question_works

### DIFF
--- a/pages/desktop/questions_page.py
+++ b/pages/desktop/questions_page.py
@@ -105,6 +105,7 @@ class AskNewQuestionsPage(Base):
     _sort_no_replies_link_locator = (By.CSS_SELECTOR, 'a[href*=filter=no-replies]')
     _questions_list_locator = (By.CSS_SELECTOR, 'div.questions > section')
     _solved_or_unsolved_text_locator = (By.CSS_SELECTOR, 'div.thread-meta > div')
+    _close_stage_banner_locator = (By.CLASS_NAME, 'close-button')
 
     def click_firefox_product_link(self):
         self.selenium.find_element(*self._firefox_product_first_link_locator).click()
@@ -131,6 +132,9 @@ class AskNewQuestionsPage(Base):
     def sorted_list_filter_text(self, question_number):
         return self.selenium.find_elements(*self._questions_list_locator)[question_number - 1].find_element(*self._solved_or_unsolved_text_locator).text
 
+    def close_stage_site_banner(self):
+        self.selenium.find_element(*self._close_stage_banner_locator).click()
+
 
 class ViewQuestionPage(Base):
 
@@ -145,7 +149,7 @@ class ViewQuestionPage(Base):
         if self._page_title:
             page_title = self.page_title
             Assert.equal(page_title, question_name + self._page_title,
-                         "Expected page title: %s. Actual page title: %s" % \
+                         "Expected page title: %s. Actual page title: %s" %
                          (question_name + self._page_title, page_title))
 
     @property

--- a/tests/desktop/test_questions.py
+++ b/tests/desktop/test_questions.py
@@ -26,6 +26,7 @@ class TestQuestions:
         ask_new_questions_page.click_firefox_product_link()
         ask_new_questions_page.click_category_problem_link()
         ask_new_questions_page.type_question(q_to_ask)
+        ask_new_questions_page.close_stage_site_banner()
         ask_new_questions_page.click_none_of_these_solve_my_problem_button()
         view_question_pg = ask_new_questions_page.fill_up_questions_form(q_to_ask, q_details)
 


### PR DESCRIPTION
This test is failing because the "staging site banner" is blocking the "<code>none_of_these_solve_my_problem_button</code>", so I added this walk-around method to close the banner first.
This is a screenshot http://qa-selenium.mv.mozilla.com:8080/job/sumo.fft.saucelabs/1425/HTML_Report/debug/tests_desktop_test_questions_TestQuestions/test_that_posting_question_works/screenshot.png
