### PR TITLE
Fix broken tests by clicking on the Topic header before trying to select a topic

### DIFF
--- a/pages/desktop/base.py
+++ b/pages/desktop/base.py
@@ -21,6 +21,10 @@ class Base(Page):
     firefox_android_product_locator = (By.CSS_SELECTOR, '#product-cards > li:nth-of-type(2) > a')
     firefoxos_product_locator = (By.CSS_SELECTOR, '#product-cards > li:nth-of-type(3) > a')
 
+    def __init__(self, testsetup):
+        super(Base, self).__init__(testsetup)
+        self.header.dismiss_staging_site_warning_if_present()
+
     def click_card_grid(self, locator):
         ActionChains(self.selenium).move_to_element(
             self.selenium.find_element(*locator)).click().perform()
@@ -87,7 +91,8 @@ class Base(Page):
 
         def dismiss_staging_site_warning_if_present(self):
             if self.is_element_present(*self._staging_site_warning_close_button_locator):
-                self.selenium.find_element(*self._staging_site_warning_close_button_locator).click()
+                if self.is_element_visible(*self._staging_site_warning_close_button_locator):
+                    self.selenium.find_element(*self._staging_site_warning_close_button_locator).click()
 
         @property
         def is_user_logged_in(self):

--- a/pages/desktop/knowledge_base_article.py
+++ b/pages/desktop/knowledge_base_article.py
@@ -99,6 +99,7 @@ class KnowledgeBaseEditArticle(KnowledgeBase):
     _article_keywords_box_locator = (By.ID, 'id_keywords')
     _article_summary_box_locator = (By.ID, 'id_summary')
     _article_content_object = 'window.highlighting.editor'
+    _article_topic_expander_locator = (By.CSS_SELECTOR, '#accordion li strong')
     _article_topic_locator = (By.CSS_SELECTOR, 'input[name=topics]')
     _article_product_locator = (By.CSS_SELECTOR, 'input[name=products]')
     _article_submit_btn_locator = (By.CSS_SELECTOR, '.btn-submit')
@@ -157,6 +158,7 @@ class KnowledgeBaseEditArticle(KnowledgeBase):
 
     def check_article_topic(self, index):
         index = index - 1
+        self.selenium.find_element(*self._article_topic_expander_locator).click()
         self.selenium.find_elements(*self._article_topic_locator)[index].click()
 
     def check_article_product(self, index):

--- a/pages/desktop/knowledge_base_new_article.py
+++ b/pages/desktop/knowledge_base_new_article.py
@@ -26,6 +26,7 @@ class KnowledgeBaseNewArticle(Base):
     _article_summary_box_locator = (By.ID, 'id_summary')
     _article_content_box_locator = (By.CSS_SELECTOR, '#editor > textarea')
     _article_slug_box_locator = (By.ID, 'id_slug')
+    _article_topic_expander_locator = (By.CSS_SELECTOR, '#accordion li strong')
     _article_topic_locator = (By.CSS_SELECTOR, 'input[name=topics]')
     _article_topic_label_locator = (By.CSS_SELECTOR, '.topics label')
     _article_product_locator = (By.CSS_SELECTOR, 'input[name=products]')
@@ -60,6 +61,7 @@ class KnowledgeBaseNewArticle(Base):
         select_box.select_by_visible_text(category)
 
     def check_first_article_topic(self):
+        self.selenium.find_element(*self._article_topic_expander_locator).click()
         self.selenium.find_element(*self._article_topic_locator).click()
 
     def check_article_product(self, product):

--- a/pages/desktop/page_provider.py
+++ b/pages/desktop/page_provider.py
@@ -20,6 +20,7 @@ class PageProvider():
         page_object.is_the_current_page
         if (do_login):
             page_object.sign_in(user)
+        page_object.header.dismiss_staging_site_warning_if_present()
         return page_object
 
     def _go_to_page_with_login_redirect(self, page_object, user='default'):
@@ -29,6 +30,7 @@ class PageProvider():
         login_page = LoginPage(self.testsetup)
         login_page.log_in(user)
         page_object.is_the_current_page
+        page_object.header.dismiss_staging_site_warning_if_present()
         return page_object
 
     ''' pages for which login is forbidden '''


### PR DESCRIPTION
Also adds code to attempt to dismiss the staging message on each page. That was also causing problems with these tests. The code I added isn't guaranteed to dismiss the message every time, but it should address most cases, and we may have to address others than come up on a case-by-case basis.

This fixes the 7 failures as seen at http://qa-selenium.mv.mozilla.com:8080/view/SUMO/job/sumo.dev/5828/testReport/

Adhoc run on Jenkins: http://qa-selenium.mv.mozilla.com:8080/job/sumo.stage.saucelabs.topic_fix/5/
