### PR TITLE
Broken locator making test to skip

### DIFF
--- a/pages/desktop/questions_page.py
+++ b/pages/desktop/questions_page.py
@@ -21,7 +21,7 @@ class QuestionsPage(Base):
     _sort_solved_link_locator = (By.CSS_SELECTOR, 'a[href*="filter=solved"]')
     _sort_unsolved_link_locator = (By.CSS_SELECTOR, 'a[href*="filter=unsolved"]')
     _sort_no_replies_link_locator = (By.CSS_SELECTOR, 'a[href*="filter=no-replies"]')
-    _questions_list_block_locator = (By.CSS_SELECTOR, 'div.questions')
+    _questions_list_block_locator = (By.CSS_SELECTOR, '.questions > section[id*="question"]')
     _questions_list_locator = (By.CSS_SELECTOR, 'article.questions > section')
 
     def click_ask_new_questions_link(self):

--- a/tests/desktop/test_search.py
+++ b/tests/desktop/test_search.py
@@ -7,6 +7,7 @@ import pytest
 from pages.desktop.page_provider import PageProvider
 from pages.desktop.search_page import SearchPage
 
+
 class TestSearch:
 
     forum_search_term = "Firefox crash"
@@ -28,25 +29,24 @@ class TestSearch:
 
     @pytest.mark.nondestructive
     def test_user_flow_to_forum_post(self, mozwebqa):
-           
+
         if mozwebqa.base_url == 'https://support-dev.allizom.org':
             pytest.skip('Search results are not guaranteed to exist on support-dev.allizom.org')
 
         #1. start on the home page
         home_pg = PageProvider(mozwebqa).home_page()
-        
+
         #2. type "Firefox crashed"
-        #3. hit Enter 
+        #3. hit Enter
         search_pg = SearchPage(mozwebqa)
         search_pg.do_search_on_search_query(self.forum_search_term+"ed")
-        
-        #4. In the results list there are two types of results: 
-        #   Forum and KB. Click on a forum result. 
+
+        #4. In the results list there are two types of results:
+        #   Forum and KB. Click on a forum result.
         #   (Url is in the forum of /questions/[some number])
         #5. A complete forum thread should be displayed.
         Assert.true(search_pg.is_result_present, "result page is not present.")
         result_thread_title = search_pg.result_question_text()
         Assert.contains(self.forum_search_term, result_thread_title)
-        is_reached_right_page = search_pg.click_question_link(self.forum_search_term) 
-	Assert.true(is_reached_right_page, "a form thread page is not displayed.")
-             
+        is_reached_right_page = search_pg.click_question_link(self.forum_search_term)
+        Assert.true(is_reached_right_page, "a form thread page is not displayed.")


### PR DESCRIPTION
This location was not correct so the test was always skipping
<code>if not questions_page.are_questions_present:
            pytest.skip("No questions present for filter=%s" % expected_sorted_text)</code>
