### PR TITLE
Added a dismiss staging warning after changing the language.

### DIFF
--- a/pages/desktop/knowledge_base_article.py
+++ b/pages/desktop/knowledge_base_article.py
@@ -189,6 +189,7 @@ class KnowledgeBaseTranslate(KnowledgeBase):
 
     def click_translate_language(self, language):
         self.selenium.find_element(By.LINK_TEXT, language).click()
+        self.header.dismiss_staging_site_warning_if_present()
 
     @property
     def is_type_title_visible(self):


### PR DESCRIPTION
After changing the language a new staging warning banner is displayed, but no new page object is returned. The banner affects some of the tests.
