### PR TITLE
Wait for the delete confirmation button to disappear.

### DIFF
--- a/pages/desktop/knowledge_base_article.py
+++ b/pages/desktop/knowledge_base_article.py
@@ -7,6 +7,7 @@ from selenium.webdriver.common.by import By
 from unittestzero import Assert
 from pages.desktop.base import Base
 from pages.page import Page
+from selenium.webdriver.support.ui import WebDriverWait
 
 
 class KnowledgeBase(Base):
@@ -241,6 +242,8 @@ class KnowledgeBaseShowHistory(KnowledgeBase):
     def delete_entire_article_document(self):
         self.click_delete_entire_article_document()
         self.click_delete_confirmation_button()
+        WebDriverWait(self.selenium, self.timeout).until(
+            lambda s: not self.is_element_present(*self._delete_confirmation_btn_locator))
 
     def click_delete_entire_article_document(self):
         self.selenium.find_element(*self._delete_document_link_locator).click()


### PR DESCRIPTION
test_that_article_can_be_deleted has been failing on Jenkins because it would refresh the page too soon.

http://selenium.qa.mtv2.mozilla.com:8080/view/All%20not%20B2G/job/sumo.stage/1358/HTML_Report/
