### PR TITLE
Added a wait for the topics to be visible.

### DIFF
--- a/pages/desktop/knowledge_base_article.py
+++ b/pages/desktop/knowledge_base_article.py
@@ -149,7 +149,7 @@ class KnowledgeBaseEditArticle(KnowledgeBase):
     def open_description_form(self):
         if not self.is_element_visible(*self._article_topic_locator):
             self.selenium.find_element(*self._description_form_toggle_locator).click()
-            self.wait_for_element_present(*self._article_topic_locator)
+            self.wait_for_element_visible(*self._article_topic_expander_locator)
 
     def save_description_form(self):
         self.selenium.find_element(*self._description_form_save_locator).click()
@@ -157,6 +157,7 @@ class KnowledgeBaseEditArticle(KnowledgeBase):
     def check_article_topic(self, index):
         index = index - 1
         self.selenium.find_element(*self._article_topic_expander_locator).click()
+        self.wait_for_element_visible(*self._article_topic_locator)
         self.selenium.find_elements(*self._article_topic_locator)[index].click()
 
     def check_article_product(self, index):


### PR DESCRIPTION
test_that_article_can_be_edited is failing on Jenkins because the test tries to select a topic even though they are not visible. This might be caused by the fact that the list did not expend fast enough.

http://selenium.qa.mtv2.mozilla.com:8080/view/All%20not%20B2G/job/sumo.stage/1358/HTML_Report/

Also change a wait from present to visible in open_description_form. The elements are always present, they are just hidden.
