### PR TITLE
Fixes issue #290

### DIFF
--- a/pages/desktop/questions_page.py
+++ b/pages/desktop/questions_page.py
@@ -44,7 +44,11 @@ class QuestionsPage(Base):
         self.selenium.find_element(*self._all_questions_tab_locator).click()
 
     def click_sort_by_unanswered_questions(self):
-        self.selenium.find_element(*self._sort_unanswered_locator).click()
+        # Prevent Selenium automatically scrolling this element to the top of
+        # the page, which can lead to unintented  clicks on the banner
+        element = self.selenium.find_element(*self._sort_unanswered_locator)
+        self.selenium.execute_script('arguments[0].scrollIntoView(false);', element)
+        element.click()
 
     def click_sort_by_solved_questions(self):
         self.selenium.find_element(*self._sort_solved_link_locator).click()
@@ -90,7 +94,11 @@ class QuestionsPage(Base):
         def click_question_link(self):
             question_title = self.title
             product_name = self.product_name
-            self._root_element.find_element(*self._question_link_locator).click()
+            # Prevent Selenium automatically scrolling this element to the top
+            # of the page, which can lead to unintented  clicks on the banner
+            element = self._root_element.find_element(*self._question_link_locator)
+            self.selenium.execute_script('arguments[0].scrollIntoView(false);', element)
+            element.click()
             view_question_pg = ViewQuestionPage(self.testsetup)
             view_question_pg.is_the_current_page(question_title, product_name)
             return view_question_pg
@@ -181,7 +189,11 @@ class ViewQuestionPage(Base):
         return self.selenium.find_element(*self._detail_locator).text
 
     def click_problem_too_button(self):
-        self.selenium.find_element(*self._problem_too_button_locator).click()
+        # Prevent Selenium automatically scrolling this element to the top of
+        # the page, which can lead to unintented  clicks on the banner
+        element = self.selenium.find_element(*self._problem_too_button_locator)
+        self.selenium.execute_script('arguments[0].scrollIntoView(false);', element)
+        element.click()
         self.wait_for_element_present(*self._no_thanks_link_locator)
 
     @property

--- a/pages/desktop/questions_page.py
+++ b/pages/desktop/questions_page.py
@@ -208,16 +208,16 @@ class ViewQuestionPage(Base):
 
     def is_reply_text_present(self, username, reply_text):
         is_reply_present = False
-        #get a list of answers
+        # get a list of answers
         answers = reversed(self.selenium.find_elements(*self._answers_locator))
-        #check if there exists a reply the user replied as "reply"
+        # check if there exists a reply the user replied as "reply"
         for answer in answers:
-            #name of the person who authored a post (name of a replyer)
+            # name of the person who authored a post (name of a replyer)
             post_author_name = answer.find_element(*self._post_author_locator).text.lower()
-            #content of the post
+            # content of the post
             post_content = answer.find_element(*self._post_content_locator).text
-            #there should exist a post, whose content is "reply" and
-            #the author is the person who logged in with username
+            # there should exist a post, whose content is "reply" and
+            # the author is the person who logged in with username
             if username.lower() == post_author_name and post_content == reply_text:
                 is_reply_present = True
                 break


### PR DESCRIPTION
If we let Selenium scroll elements into view it scrolls them to the top of the page. In the case of SUMO this means the elements might then be under the page banner, so any subsequent clicks hit the wrong coordinates. There's not a great solution for this, so I've just made sure the two places we were seeing issues are preceded by scrolling the element to the bottom of the page.